### PR TITLE
Addition of unloadBeforeLoad property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Check out [C3.js Reference](http://c3js.org/reference.html) for more details.
 * gauge
 * className
 * style
+* unloadBeforeLoad
 
 ## License
 

--- a/react-c3js.js
+++ b/react-c3js.js
@@ -59,11 +59,21 @@ var C3Chart = function (_React$Component) {
       this.chart.load(data);
     }
   }, {
+    key: 'unloadData',
+    value: function unloadData() {
+      this.chart.unload();
+    }
+  }, {
     key: 'updateChart',
     value: function updateChart(config) {
       if (!this.chart) {
         this.chart = this.generateChart((0, _reactDom.findDOMNode)(this), config);
       }
+
+      if (config.unloadBeforeLoad) {
+        this.unloadData();
+      }
+
       this.loadNewData(config.data);
     }
   }, {
@@ -119,7 +129,8 @@ var C3Chart = function (_React$Component) {
         donut: _react2.default.PropTypes.object,
         gauge: _react2.default.PropTypes.object,
         className: _react2.default.PropTypes.string,
-        style: _react2.default.PropTypes.object
+        style: _react2.default.PropTypes.object,
+        unloadBeforeLoad: _react2.default.PropTypes.bool
       };
     }
   }]);

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,8 @@ class C3Chart extends React.Component {
       donut: React.PropTypes.object,
       gauge: React.PropTypes.object,
       className: React.PropTypes.string,
-      style: React.PropTypes.object
+      style: React.PropTypes.object,
+      unloadBeforeLoad: React.PropTypes.bool,
     };
   }
 
@@ -63,10 +64,19 @@ class C3Chart extends React.Component {
     this.chart.load(data);
   }
 
+  unloadData() {
+      this.chart.unload();
+  }
+
   updateChart(config) {
     if (!this.chart) {
       this.chart = this.generateChart(findDOMNode(this), config);
     }
+
+    if (config.unloadBeforeLoad) {
+        this.unloadData();
+    }
+
     this.loadNewData(config.data);
   }
 


### PR DESCRIPTION
If set to true, the chart will call unload (http://c3js.org/reference.html#api-unload) before loading new data on property update. This allows a user to load in new data, without full regeneration. Primarily this just allows you to take advantage of c3's smooth transitions.

Note Issue 15: https://github.com/bcbcarl/react-c3js/issues/15

Possible future feature if this proves popular is a unloadIds property, allowing for unloading of specific data.