### PR TITLE
Provide hook to get changed props along with the internal chart object

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Check out [C3.js Reference](http://c3js.org/reference.html) for more details.
 * className
 * style
 * unloadBeforeLoad
+* onPropsChanged
 
 ## License
 

--- a/react-c3js.js
+++ b/react-c3js.js
@@ -47,6 +47,9 @@ var C3Chart = function (_React$Component) {
     key: 'componentWillReceiveProps',
     value: function componentWillReceiveProps(newProps) {
       this.updateChart(newProps);
+      if (newProps.onPropsChanged) {
+        newProps.onPropsChanged(this.props, newProps, this.chart);
+      }
     }
   }, {
     key: 'componentWillUnmount',
@@ -136,7 +139,8 @@ var C3Chart = function (_React$Component) {
         gauge: _propTypes2.default.object,
         className: _propTypes2.default.string,
         style: _propTypes2.default.object,
-        unloadBeforeLoad: _propTypes2.default.bool
+        unloadBeforeLoad: _propTypes2.default.bool,
+        onPropsChanged: _propTypes2.default.func
       };
     }
   }]);

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ class C3Chart extends React.Component {
       className: PropTypes.string,
       style: PropTypes.object,
       unloadBeforeLoad: PropTypes.bool,
+      onPropsChanged: PropTypes.func,
     };
   }
 
@@ -50,6 +51,9 @@ class C3Chart extends React.Component {
 
   componentWillReceiveProps(newProps) {
     this.updateChart(newProps);
+    if (newProps.onPropsChanged) {
+      newProps.onPropsChanged(this.props, newProps, this.chart);
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
This would allow consumers to interact with the internal chart, call C3 API methods when something changed such as show/hide bools, legend, formats, etc. (anything but chart data)