### PR TITLE
Update c3.js dependency to support 'drag' zoom style

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "react-dom": "^15.5.0 || ^16.0.0"
   },
   "dependencies": {
-    "c3": "^0.4.11"
+    "c3": "^0.7.12"
   },
   "devDependencies": {
     "@types/c3": "^0.4.41",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-c3js",
-  "version": "0.1.20",
+  "version": "0.2.1",
   "description": "React component for C3.js",
   "main": "react-c3js.js",
   "files": [


### PR DESCRIPTION
Current mainline uses c3 0.4.11 which is getting quite old.  In particular it does not support the zoom type of 'drag' which allows zoom without the scroll action of a page being hijacked by the chart.
Updating has not caused any issue in our application and by the semantic versioning and changelog it should not in theory cause any problems.

Updated c3js to 0.7.12